### PR TITLE
chore(gulp): refactor tasks to ensure all files are copied

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "devDependencies": {
     "bower": "~1.3.5",
     "clientify": "git://github.com/vojtajina/clientify#shrinkwrap",
-    "gulp": "3.5.6",
+    "event-stream": "^3.1.5",
+    "gulp": "^3.8.2",
     "gulp-clean": "^0.3.1",
     "gulp-connect": "~1.0.5",
     "gulp-traceur": "vojtajina/gulp-traceur#traceur-as-peer",
@@ -49,6 +50,6 @@
     "protractor": "~1.0.0",
     "requirejs": "^2.1.11",
     "rtts-assert": "angular/assert",
-    "through2": "^0.4.1"
+    "run-sequence": "^0.3.6"
   }
 }


### PR DESCRIPTION
Previously, only 16 of the files from the 'templating' dependency were being copied.
I believe this is due to Gulp terminating before all the files had been written.

This refactoring ensures that all streams are complete before gulp exits - you do this by
returning a stream from the task.  This is tricky to do if you have multiple streams in a
single task. In this case we use the event-stream `merge()` function to turn multiple
streams into a single one for returning.

In addition, the clean task is now run using `runSequence`, which decouples it from the
other tasks so that we don't have to add it as a dependency of every task.
